### PR TITLE
Add onValidationFail option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /vendor/
 /.git/
 /recette/
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pierre-granger/apidae-ecriture",
     "description": "Classe de simplification pour l'écriture sur Apidae",
     "require": {
-        "php": "^7.0|^8.0",
+        "php": "^7.4|^8.0",
         "pierre-granger/apidae-core": "^0.6"
     },
     "autoload": {

--- a/src/ApidaeEcriture.php
+++ b/src/ApidaeEcriture.php
@@ -14,6 +14,8 @@ class ApidaeEcriture extends ApidaeCore
 {
     public $skipValidation = false;
 
+    public ?string $onValidationFail = null;
+
     public $statuts_api_ecriture = [
         'CREATION_VALIDATION_SKIPPED', 'CREATION_VALIDATION_ASKED',
         'MODIFICATION_VALIDATION_SKIPPED', 'MODIFICATION_VALIDATION_ASKED',
@@ -59,6 +61,10 @@ class ApidaeEcriture extends ApidaeCore
         if (isset($params['skipValidation'])) {
             $this->skipValidation = $params['skipValidation'] ? true : false;
         }
+
+        if (isset($params['onValidationFail'])) {
+            $this->onValidationFail = $params['onValidationFail'];
+        }
     }
 
     public function enregistrer($params = null): bool
@@ -93,6 +99,12 @@ class ApidaeEcriture extends ApidaeCore
             $postfields['skipValidation'] = $params['skipValidation'] ? 'true' : 'false';
         } else {
             $postfields['skipValidation'] = $this->skipValidation ? 'true' : 'false';
+        }
+
+        if (isset($params['onValidationFail'])) {
+            $postfields['onValidationFail'] = $params['onValidationFail'];
+        } elseif (!is_null($this->onValidationFail)) {
+            $postfields['onValidationFail'] = $this->onValidationFail;
         }
 
         if (isset($params['tokenSSO'])) {


### PR DESCRIPTION
- Changed minimum php version to 7.4 because property typing is used and is only available since 7.4
- Add onValidationFail option both in global params and in `enregistrer()` method params

Since it is a `string`, it could be interesting to check if it is a valid string before sending it but I don't know what are the available options because it i not documented yet. 