### PR TITLE
Remove ? in proprety because not available before php 7.4

### DIFF
--- a/src/ApidaeEcriture.php
+++ b/src/ApidaeEcriture.php
@@ -14,7 +14,7 @@ class ApidaeEcriture extends ApidaeCore
 {
     public $skipValidation = false;
 
-    public ?string $onValidationFail = null;
+    public string $onValidationFail = null;
 
     public $statuts_api_ecriture = [
         'CREATION_VALIDATION_SKIPPED', 'CREATION_VALIDATION_ASKED',


### PR DESCRIPTION
Need to remove the `?` in the property typing as this doesn't work before php 7.4.